### PR TITLE
Use generalized SSE event names

### DIFF
--- a/src/features/charts/components/stock-chart-container.tsx
+++ b/src/features/charts/components/stock-chart-container.tsx
@@ -58,7 +58,7 @@ export const StockChartContainer = ({ ticker }: StockChartProps) => {
   const loadStockData = useLoadStockChartData();
 
   const { cleanup } = useSSE({
-    events: new Set([ticker]),
+    events: new Set([`PRICE_UPDATE_${ticker}`]),
     callback: (eventData) => {
       let jsonData;
       try {

--- a/src/features/instruments/components/instruments-table-container.tsx
+++ b/src/features/instruments/components/instruments-table-container.tsx
@@ -61,7 +61,7 @@ const InstrumentsTableContainer = ({
 
   const tickersSet = useMemo(
     () => {
-      return new Set(tickers);
+      return new Set(tickers.map((ticker) => `PRICE_UPDATE_${ticker}`));
     },
     [tickers.join(',')] // eslint-disable-line react-hooks/exhaustive-deps
   );


### PR DESCRIPTION
# Summary

Updated the SSE (Server-Sent Events) implementation to use a more specific event naming convention. Events are now prefixed with `PRICE_UPDATE_` to better identify price update events. This change affects both the stock chart container and instruments table components.

Key changes:
- Modified event naming to use `PRICE_UPDATE_${ticker}` format
- Changed the backend API request payload to use `events` instead of `symbols`
- Updated SSE consumption to filter events properly

This has to be tested with `stocks-backend/07-02-generalize_sse_to_different_events` branch