### PR TITLE
Make the skeleton of instruments table container of PAGE_SIZE height

### DIFF
--- a/src/features/instruments/components/instruments-table-container.tsx
+++ b/src/features/instruments/components/instruments-table-container.tsx
@@ -117,6 +117,7 @@ const InstrumentsTableContainer = ({
       <InstrumentTable
         data={Object.values(liveInstruments)}
         onInstrumentPressed={handleInstrumentPressed}
+        rowCount={PAGE_SIZE}
         loading={loading && instruments.length === 0}
       />
       <div className="flex justify-center mt-4">

--- a/src/features/instruments/components/instruments-table.tsx
+++ b/src/features/instruments/components/instruments-table.tsx
@@ -14,18 +14,20 @@ import { cn } from '@/features/shared/utils';
 type InstrumentTableProps = {
   data: Array<Instrument>;
   onInstrumentPressed: (instrument: Instrument) => void;
+  rowCount?: number;
   loading?: boolean;
 };
 
 const InstrumentTable = ({
   data,
   onInstrumentPressed,
+  rowCount = 10,
   loading = false,
 }: InstrumentTableProps) => {
   const { t } = useTranslation();
 
   const renderSkeletonRows = () => {
-    return Array.from({ length: 5 }).map((_, idx) => (
+    return Array.from({ length: rowCount }).map((_, idx) => (
       <TableRow key={`skeleton-${idx}`}>
         <TableCell className="hidden sm:table-cell h-10">
           <Skeleton className="h-4 w-32" />


### PR DESCRIPTION
# Summary

Added a `rowCount` prop to the `InstrumentTable` component to control the number of skeleton rows displayed during loading states. The default value is set to 10, and the `InstrumentsTableContainer` now passes the `PAGE_SIZE` constant to ensure the skeleton loading state matches the actual number of rows that will be displayed when data loads.
