### PR TITLE
Enrich PostHog events with Clerk user data

### DIFF
--- a/src/features/instruments/components/buy-sell-action.tsx
+++ b/src/features/instruments/components/buy-sell-action.tsx
@@ -1,6 +1,7 @@
 // BuySellSection.tsx
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { usePostHog } from 'posthog-js/react';
 import { TabsContent } from '@radix-ui/react-tabs';
 import { IconChevronDown } from '@tabler/icons-react';
 import { Card, CardContent } from '@/features/shared/components/ui/card';
@@ -28,6 +29,20 @@ export const BuySellSection = ({
   onModeToggle,
 }: BuySellSectionProps) => {
   const { t } = useTranslation();
+  const posthog = usePostHog();
+
+  const handleTradeAction = (actionType: 'buy' | 'sell') => {
+    posthog.capture('trade_action', {
+      action_type: actionType,
+      mode,
+      value,
+      derivedValue,
+      price: mode === 'price' ? value : derivedValue,
+      volume: mode === 'volume' ? value : derivedValue,
+    });
+    // NOTE: This is where the actual buy/sell logic would be triggered.
+  };
+
   const handleInputChange = (val: number | null | undefined) => {
     if (typeof val === 'number' && !isNaN(val)) {
       onValueChange(val);
@@ -83,10 +98,16 @@ export const BuySellSection = ({
             </div>
 
             <div className="flex gap-3 mt-4">
-              <Button className="bg-green-600 hover:bg-green-700 flex-1">
+              <Button
+                className="bg-green-600 hover:bg-green-700 flex-1"
+                onClick={() => handleTradeAction('buy')}
+              >
                 {t('instruments.buy')}
               </Button>
-              <Button className="bg-red-600 hover:bg-red-700  flex-1">
+              <Button
+                className="bg-red-600 hover:bg-red-700  flex-1"
+                onClick={() => handleTradeAction('sell')}
+              >
                 {t('instruments.sell')}
               </Button>
             </div>

--- a/src/features/shared/providers/user-enhanced-posthog-provider.tsx
+++ b/src/features/shared/providers/user-enhanced-posthog-provider.tsx
@@ -1,0 +1,65 @@
+import { useAuth, useUser } from '@clerk/clerk-react';
+import { useRouter } from '@tanstack/react-router';
+import { PostHogProvider, usePostHog } from 'posthog-js/react';
+import { useEffect } from 'react';
+
+const PostHogUserIdentification = () => {
+  const posthog = usePostHog();
+  const { isSignedIn, userId, isLoaded } = useAuth();
+  const { user } = useUser();
+
+  useEffect(() => {
+    if (isLoaded && isSignedIn && user && userId) {
+      posthog.identify(userId, {
+        email: user.primaryEmailAddress?.emailAddress,
+        username: user.username,
+        fullName: user.fullName,
+      });
+    } else if (posthog._isIdentified()) {
+      posthog.reset();
+    }
+  }, [posthog, isSignedIn, user, userId, isLoaded]);
+
+  return null;
+};
+
+const PostHogPageView = () => {
+  const posthog = usePostHog();
+  const router = useRouter();
+
+  useEffect(() => {
+    const unsubscribe = router.subscribe('onResolved', () => {
+      posthog.capture('$pageview', {
+        $current_url: window.location.href,
+      });
+    });
+
+    return unsubscribe;
+  }, [posthog, router]);
+
+  return null;
+};
+
+interface UserEnhancedPostHogProviderProps {
+  phKey: string;
+  phHost: string;
+  children: React.ReactNode;
+}
+
+export const UserEnhancedPostHogProvider = ({
+  phKey,
+  phHost,
+  children,
+}: UserEnhancedPostHogProviderProps) => (
+  <PostHogProvider
+    apiKey={phKey}
+    options={{
+      api_host: phHost,
+      capture_pageview: false,
+    }}
+  >
+    <PostHogUserIdentification />
+    <PostHogPageView />
+    {children}
+  </PostHogProvider>
+);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,11 @@ import ReactDOM from 'react-dom/client';
 import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { StrictMode } from 'react';
-import { PostHogProvider } from 'posthog-js/react';
 import { routeTree } from './routeTree.gen';
-import { SSEProvider } from './features/shared/providers/sse-provider.tsx';
-import reportWebVitals from './reportWebVitals.ts';
-import { ThemeProvider } from '@/features/shared/components/theme-provider.tsx';
-import { ClerkThemedProvider } from '@/features/shared/providers/clerk-themed-provider.tsx';
+import { SSEProvider } from './features/shared/providers/sse-provider';
+import reportWebVitals from './reportWebVitals';
+import { ThemeProvider } from '@/features/shared/components/theme-provider';
+import { ClerkThemedProvider } from '@/features/shared/providers/clerk-themed-provider';
 import './i18n/config.ts';
 import './styles.css';
 
@@ -31,16 +30,6 @@ if (!CLERK_PUBLIC_KEY) {
   throw new Error('Missing Clerk Publishable Key');
 }
 
-const POSTHOG_KEY = import.meta.env.VITE_PUBLIC_POSTHOG_KEY;
-if (!POSTHOG_KEY) {
-  throw new Error('VITE_PUBLIC_POSTHOG_KEY is not defined');
-}
-
-const POSTHOG_HOST = import.meta.env.VITE_PUBLIC_POSTHOG_HOST;
-if (!POSTHOG_HOST) {
-  throw new Error('VITE_PUBLIC_POSTHOG_HOST is not defined');
-}
-
 const queryClient = new QueryClient();
 
 const rootElement = document.getElementById('app');
@@ -50,16 +39,11 @@ if (rootElement && !rootElement.innerHTML) {
     <StrictMode>
       <ThemeProvider>
         <ClerkThemedProvider publicKey={CLERK_PUBLIC_KEY}>
-          <PostHogProvider
-            apiKey={POSTHOG_KEY}
-            options={{ api_host: POSTHOG_HOST }}
-          >
-            <QueryClientProvider client={queryClient}>
-              <SSEProvider>
-                <RouterProvider router={router} />
-              </SSEProvider>
-            </QueryClientProvider>
-          </PostHogProvider>
+          <QueryClientProvider client={queryClient}>
+            <SSEProvider>
+              <RouterProvider router={router} />
+            </SSEProvider>
+          </QueryClientProvider>
         </ClerkThemedProvider>
       </ThemeProvider>
     </StrictMode>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,3 +1,22 @@
-import { createRootRoute } from '@tanstack/react-router';
+import { Outlet, createRootRoute } from '@tanstack/react-router';
+import { UserEnhancedPostHogProvider } from '@/features/shared/providers/user-enhanced-posthog-provider';
 
-export const Route = createRootRoute();
+const POSTHOG_KEY = import.meta.env.VITE_PUBLIC_POSTHOG_KEY;
+if (!POSTHOG_KEY) {
+  throw new Error('VITE_PUBLIC_POSTHOG_KEY is not defined');
+}
+
+const POSTHOG_HOST = import.meta.env.VITE_PUBLIC_POSTHOG_HOST;
+if (!POSTHOG_HOST) {
+  throw new Error('VITE_PUBLIC_POSTHOG_HOST is not defined');
+}
+
+export const Route = createRootRoute({
+  component: () => (
+    <>
+      <UserEnhancedPostHogProvider phKey={POSTHOG_KEY} phHost={POSTHOG_HOST}>
+        <Outlet />
+      </UserEnhancedPostHogProvider>
+    </>
+  ),
+});


### PR DESCRIPTION
# Summary

- Now we identify users and save the information in events' metadata in posthog.
- We're handling pageview manually, since it's firing too early, before we identify the user

## Related Issue

Closes #78 
