### PR TITLE
Fix `<UserButton />`'s popover not being able to click on narrow viewports

### DIFF
--- a/src/features/shared/components/nav-user.tsx
+++ b/src/features/shared/components/nav-user.tsx
@@ -39,9 +39,11 @@ export function NavUser({ user }: NavUserProps) {
               appearance={{
                 elements: {
                   userButtonPopoverCard: {
-                    marginTop: '-8px',
-                    marginLeft: '-8px',
-                    borderRadius: '6px',
+                    pointerEvents: 'initial', // Allow interaction on smaller screens
+                    marginTop: '-8px', // Adjust vertical positioning
+                    marginLeft: '-8px', // Align with the left edge of SidebarMenuItem
+                    maxWidth: 'calc(100vw - 16px)', // Ensure popover fits within viewport
+                    borderRadius: 'var(--radius)', // Apply consistent border radius
                   },
                 },
               }}


### PR DESCRIPTION
# Summary

- fix: User button's popover was not clickable (user could not eg logout) on narrow viewport
- popover stays centered (and matches SidebarMenuItem width) on narrow viewports
- border-radius is consistent - uses `var(--radius)`
