### PR TITLE
Implement breadcrumbs

### DIFF
--- a/src/features/shared/components/app-frame.tsx
+++ b/src/features/shared/components/app-frame.tsx
@@ -1,0 +1,21 @@
+import { AppSidebar } from './app-sidebar';
+import { SiteHeader } from './site-header';
+import { SidebarInset, SidebarProvider } from './ui/sidebar';
+import { getCookie } from '@/features/transactions/utils/cookies';
+
+interface AppFrameProps {
+  children: React.ReactNode;
+}
+
+export default function AppFrame({ children }: AppFrameProps) {
+  const defaultOpen = getCookie('sidebar_state') === 'true';
+  return (
+    <SidebarProvider defaultOpen={defaultOpen}>
+      <AppSidebar variant="inset" />
+      <SidebarInset>
+        <SiteHeader />
+        <div className="p-4">{children}</div>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}

--- a/src/features/shared/components/breadcrumb-nav.tsx
+++ b/src/features/shared/components/breadcrumb-nav.tsx
@@ -1,0 +1,36 @@
+import { Link, isMatch, useMatches } from '@tanstack/react-router';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+} from './ui/breadcrumb';
+
+export function BreadcrumbNav() {
+  const matches = useMatches();
+  const matchesWithCrumbs = matches.filter((match) =>
+    isMatch(match, 'loaderData.crumb')
+  );
+
+  const items = matchesWithCrumbs.map(({ pathname, loaderData }) => {
+    return {
+      href: pathname,
+      label: loaderData?.crumb,
+    };
+  });
+
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        {items.map((item, index) => (
+          <BreadcrumbItem key={index}>
+            <Link to={item.href} className="breadcrumb-link">
+              {item.label}
+            </Link>
+            {index < items.length - 1 && <BreadcrumbSeparator />}
+          </BreadcrumbItem>
+        ))}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/src/features/shared/components/site-header.tsx
+++ b/src/features/shared/components/site-header.tsx
@@ -1,11 +1,10 @@
-import { useTranslation } from 'react-i18next';
 import { LanguageToggle } from './language-toggle';
+import { BreadcrumbNav } from './breadcrumb-nav';
 import { Separator } from '@/features/shared/components/ui/separator';
 import { SidebarTrigger } from '@/features/shared/components/ui/sidebar';
 import { ThemeToggle } from '@/features/shared/components/mode-toggle';
 
 export function SiteHeader() {
-  const { t } = useTranslation();
   return (
     <header className="flex h-(--header-height) shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-(--header-height)">
       <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
@@ -14,7 +13,7 @@ export function SiteHeader() {
           orientation="vertical"
           className="mx-2 data-[orientation=vertical]:h-4"
         />
-        <h1 className="text-base font-medium">{t('common.app_name')}</h1>
+        <BreadcrumbNav />
         <div className="ml-auto flex items-center gap-2">
           <LanguageToggle />
           <ThemeToggle />

--- a/src/features/shared/components/wallet-section.tsx
+++ b/src/features/shared/components/wallet-section.tsx
@@ -23,23 +23,21 @@ export function WalletSection() {
   );
 
   return (
-    <SidebarMenuItem className="flex items-center gap-0">
-      <SidebarMenuButton tooltip={t('common.wallet')}>
-        <IconWallet />
-        {isLoading ? (
-          <Skeleton className="h-6 w-24" />
-        ) : (
-          <span>
-            {accountValue ? (
-              new Intl.NumberFormat('en-US', {
-                style: 'currency',
-                currency: t('common.currency'),
-              }).format(accountValue.value)
-            ) : (
-              <Skeleton className="h-6 w-24" />
-            )}
-          </span>
-        )}
+    <SidebarMenuItem className="flex items-center gap-1">
+      <SidebarMenuButton tooltip={t('common.wallet')} asChild>
+        <a>
+          <IconWallet />
+          {isLoading ? (
+            <Skeleton className="h-6 w-24" />
+          ) : accountValue ? (
+            new Intl.NumberFormat('en-US', {
+              style: 'currency',
+              currency: t('common.currency'),
+            }).format(accountValue.value)
+          ) : (
+            <Skeleton className="h-6 w-24" />
+          )}
+        </a>
       </SidebarMenuButton>
       <Button
         size="icon"

--- a/src/features/transactions/utils/cookies.ts
+++ b/src/features/transactions/utils/cookies.ts
@@ -1,0 +1,15 @@
+export function setCookie(name: string, value: string, days?: number): void {
+  const expires = days ? new Date(Date.now() + days * 864e5).toUTCString() : '';
+  const cookieValue = encodeURIComponent(value);
+  const expiresPart = expires ? `;expires=${expires}` : '';
+  document.cookie = `${name}=${cookieValue}${expiresPart};path=/`;
+}
+
+export function getCookie(name: string): string {
+  const match = document.cookie.match(new RegExp(`(^| )${name}=([^;]+)`));
+  return match ? decodeURIComponent(match.pop() as string) : '';
+}
+
+export function deleteCookie(name: string): void {
+  document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:01 GMT;path=/`;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { QueryClient } from '@tanstack/react-query';
 import { StrictMode } from 'react';
 import { PostHogProvider } from 'posthog-js/react';
 import { ClerkLoaded, useAuth } from '@clerk/clerk-react';
+import { useTranslation } from 'react-i18next';
 import { routeTree } from './routeTree.gen';
 import { SSEProvider } from './features/shared/providers/sse-provider.tsx';
 import { ConditionalProvider } from './features/shared/providers/conditional-provider.tsx';
@@ -32,14 +33,16 @@ const queryClient = new QueryClient({
 
 export type RouterContext = {
   auth: ReturnType<typeof useAuth>;
+  i18n: ReturnType<typeof useTranslation>;
   queryClient: QueryClient;
 };
 
-const router = createRouter({
+export const router = createRouter({
   routeTree,
   context: {
-    auth: undefined!,
     queryClient,
+    auth: undefined!,
+    i18n: undefined!,
   },
   defaultErrorComponent: ({ error }) => {
     return <ErrorComponent error={error} />;
@@ -48,7 +51,10 @@ const router = createRouter({
 
 function App() {
   const auth = useAuth();
-  return <RouterProvider context={{ auth, queryClient }} router={router} />;
+  const i18n = useTranslation();
+  return (
+    <RouterProvider context={{ queryClient, auth, i18n }} router={router} />
+  );
 }
 
 const persister = createAsyncStoragePersister({

--- a/src/routes/-components/dashboard.tsx
+++ b/src/routes/-components/dashboard.tsx
@@ -1,29 +1,20 @@
-import { AppSidebar } from '@/features/shared/components/app-sidebar';
-import { SiteHeader } from '@/features/shared/components/site-header';
-import {
-  SidebarInset,
-  SidebarProvider,
-} from '@/features/shared/components/ui/sidebar';
 import AccountOverviewRibbon from '@/features/home/components/account-overview-ribbon';
 import AssetAllocationContainer from '@/features/home/components/asset-allocation-container';
 import { AccountValueChartContainer } from '@/features/home/components/account-value-chart-container';
 import AssetTableContainer from '@/features/home/components/asset-table-container';
+import AppFrame from '@/features/shared/components/app-frame';
 
 export function Dashboard() {
   return (
-    <SidebarProvider>
-      <AppSidebar variant="inset" />
-      <SidebarInset>
-        <SiteHeader />
-        <div className="flex flex-col gap-4 p-4">
-          <AccountOverviewRibbon />
-          <div className=" grid grid-cols-1 xl:grid-cols-2 gap-4">
-            <AssetAllocationContainer />
-            <AccountValueChartContainer />
-          </div>
-          <AssetTableContainer />
+    <AppFrame>
+      <div className="flex flex-col gap-4">
+        <AccountOverviewRibbon />
+        <div className=" grid grid-cols-1 xl:grid-cols-2 gap-4">
+          <AssetAllocationContainer />
+          <AccountValueChartContainer />
         </div>
-      </SidebarInset>
-    </SidebarProvider>
+        <AssetTableContainer />
+      </div>
+    </AppFrame>
   );
 }

--- a/src/routes/_authed/instruments/$instrumentId.tsx
+++ b/src/routes/_authed/instruments/$instrumentId.tsx
@@ -1,8 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router';
 import InstrumentDetails from '@/features/instruments/components/instrument-details';
+import AppFrame from '@/features/shared/components/app-frame';
 
 export const Route = createFileRoute('/_authed/instruments/$instrumentId')({
   component: RouteComponent,
+  loader: ({ params: { instrumentId } }) => ({
+    crumb: instrumentId,
+  }),
 });
 
 function RouteComponent() {
@@ -18,5 +22,9 @@ function RouteComponent() {
     symbol: 'MOCK',
   };
 
-  return <InstrumentDetails instrument={mockInstrument} />;
+  return (
+    <AppFrame>
+      <InstrumentDetails instrument={mockInstrument} />
+    </AppFrame>
+  );
 }

--- a/src/routes/_authed/instruments/index.tsx
+++ b/src/routes/_authed/instruments/index.tsx
@@ -11,6 +11,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/features/shared/components/ui/sheet';
+import AppFrame from '@/features/shared/components/app-frame';
 
 export const Route = createFileRoute('/_authed/instruments/')({
   component: Instruments,
@@ -22,34 +23,36 @@ function Instruments() {
   const [instrument, setInstrument] = useState<Instrument>();
 
   return (
-    <Sheet open={open} onOpenChange={setOpen}>
-      <SheetContent className="w-full sm:max-w-2/3">
-        {instrument ? (
-          <>
-            <SheetHeader>
-              <SheetTitle>
-                {instrument.name} - {t('instruments.overview')}
-              </SheetTitle>
-              <SheetDescription>{t('instruments.overview')}</SheetDescription>
-            </SheetHeader>
+    <AppFrame>
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent className="w-full sm:max-w-2/3">
+          {instrument ? (
+            <>
+              <SheetHeader>
+                <SheetTitle>
+                  {instrument.name} - {t('instruments.overview')}
+                </SheetTitle>
+                <SheetDescription>{t('instruments.overview')}</SheetDescription>
+              </SheetHeader>
 
-            <div className="p-4 space-y-4 overflow-y-auto">
-              <InstrumentDetails instrument={instrument} />
+              <div className="p-4 space-y-4 overflow-y-auto">
+                <InstrumentDetails instrument={instrument} />
+              </div>
+            </>
+          ) : null}
+        </SheetContent>
+
+        <div className="flex flex-1 flex-col">
+          <div className="@container/main flex flex-1 flex-col gap-2">
+            <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
+              <InstrumentsTableContainer
+                setOpenSheet={setOpen}
+                setInstrument={setInstrument}
+              />
             </div>
-          </>
-        ) : null}
-      </SheetContent>
-
-      <div className="flex flex-1 flex-col">
-        <div className="@container/main flex flex-1 flex-col gap-2">
-          <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
-            <InstrumentsTableContainer
-              setOpenSheet={setOpen}
-              setInstrument={setInstrument}
-            />
           </div>
         </div>
-      </div>
-    </Sheet>
+      </Sheet>
+    </AppFrame>
   );
 }

--- a/src/routes/_authed/route.tsx
+++ b/src/routes/_authed/route.tsx
@@ -1,10 +1,4 @@
-import { Outlet, createFileRoute, redirect } from '@tanstack/react-router';
-import { AppSidebar } from '@/features/shared/components/app-sidebar';
-import { SiteHeader } from '@/features/shared/components/site-header';
-import {
-  SidebarInset,
-  SidebarProvider,
-} from '@/features/shared/components/ui/sidebar';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/_authed')({
   beforeLoad: ({ context: { auth } }) => {
@@ -12,15 +6,4 @@ export const Route = createFileRoute('/_authed')({
       throw redirect({ to: '/' });
     }
   },
-  component: () => (
-    <SidebarProvider>
-      <AppSidebar variant="inset" />
-      <SidebarInset>
-        <SiteHeader />
-        <div className="p-4">
-          <Outlet />
-        </div>
-      </SidebarInset>
-    </SidebarProvider>
-  ),
 });

--- a/src/routes/_authed/transactions/index.tsx
+++ b/src/routes/_authed/transactions/index.tsx
@@ -9,6 +9,7 @@ import {
   TabsTrigger,
 } from '@/features/shared/components/ui/tabs';
 import { PositionsTable } from '@/features/transactions/components/positions-table';
+import AppFrame from '@/features/shared/components/app-frame';
 
 export const Route = createFileRoute('/_authed/transactions/')({
   component: TransactionsPage,
@@ -19,23 +20,25 @@ function TransactionsPage() {
   const [tab, setTab] = useState<'open' | 'closed'>('open');
 
   return (
-    <Tabs value={tab} onValueChange={(v) => setTab(v as 'open' | 'closed')}>
-      <TabsList>
-        <TabsTrigger value="open" className="cursor-pointer text-xs">
-          <CircleDot className="opacity-80" />
-          {t('transactions.tabs.open_positions')}
-        </TabsTrigger>
-        <TabsTrigger value="closed" className="cursor-pointer text-xs">
-          <CheckCircle2 className="opacity-80" />
-          {t('transactions.tabs.closed_positions')}
-        </TabsTrigger>
-      </TabsList>
-      <TabsContent value="open">
-        <PositionsTable type="open" />
-      </TabsContent>
-      <TabsContent value="closed">
-        <PositionsTable type="closed" />
-      </TabsContent>
-    </Tabs>
+    <AppFrame>
+      <Tabs value={tab} onValueChange={(v) => setTab(v as 'open' | 'closed')}>
+        <TabsList>
+          <TabsTrigger value="open" className="cursor-pointer text-xs">
+            <CircleDot className="opacity-80" />
+            {t('transactions.tabs.open_positions')}
+          </TabsTrigger>
+          <TabsTrigger value="closed" className="cursor-pointer text-xs">
+            <CheckCircle2 className="opacity-80" />
+            {t('transactions.tabs.closed_positions')}
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="open">
+          <PositionsTable type="open" />
+        </TabsContent>
+        <TabsContent value="closed">
+          <PositionsTable type="closed" />
+        </TabsContent>
+      </Tabs>
+    </AppFrame>
   );
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -9,7 +9,7 @@ import { accountValueOverTimeQueryOptions } from '@/features/home/components/acc
 import { ownedSharesQueryOptions } from '@/features/home/components/asset-table-container';
 
 export const Route = createFileRoute('/')({
-  loader: async ({ context: { queryClient, auth } }) => {
+  loader: async ({ context: { queryClient, auth, i18n } }) => {
     if (!auth.isSignedIn) {
       return;
     }
@@ -20,6 +20,9 @@ export const Route = createFileRoute('/')({
       queryClient.prefetchQuery(accountValueOverTimeQueryOptions),
       queryClient.prefetchQuery(ownedSharesQueryOptions),
     ]);
+    return {
+      crumb: i18n.t('common.dashboard'),
+    };
   },
   component: Index,
 });


### PR DESCRIPTION
# Summary

Previously it was just 'InvestLab`, it made no sense because the name is already in the sidebar. This was the intended usage in the template, but did not have the logic since it's router dependent.

## Screenshots 

<img width="1670" height="905" alt="image" src="https://github.com/user-attachments/assets/306230b8-2816-4415-b1f4-3f73f00abc94" />
