### PR TITLE
Add extra possible value for insight's sentiment

### DIFF
--- a/src/features/instruments/types/news.ts
+++ b/src/features/instruments/types/news.ts
@@ -1,7 +1,8 @@
 import { type } from 'arktype';
 
 const insight = type({
-  sentiment: "'positive' | 'negative' | 'neutral' | 'neutral/positive'",
+  sentiment:
+    "'positive' | 'negative' | 'neutral' | 'neutral/positive' | 'neutral/negative'",
   sentiment_reasoning: 'string',
   ticker: 'string',
 });


### PR DESCRIPTION
News were validating incorrectly and caused an error.
```console
Validation failed: value at [1].insights[1].sentiment must be "negative", "neutral | " or "positive" (was "neutral")
value at [1].insights[2].sentiment must be "negative", "neutral | " or "positive" (was "neutral")
```

liars:

<img width="532" height="482" alt="image" src="https://github.com/user-attachments/assets/cbecf621-0c4e-424b-a420-437e5e4ac712" />