### PR TITLE
Fix keydown ref check and adjust button heights in NumberInput component

### DIFF
--- a/src/features/shared/components/ui/number-input.tsx
+++ b/src/features/shared/components/ui/number-input.tsx
@@ -78,7 +78,8 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
       const handleKeyDown = (e: KeyboardEvent) => {
         if (
           document.activeElement ===
-          (ref as React.RefObject<HTMLInputElement>).current
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          (ref as React.RefObject<HTMLInputElement>)?.current
         ) {
           if (e.key === 'ArrowUp') {
             e.preventDefault();
@@ -135,10 +136,10 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
           {...props}
         />
 
-        <div className="flex flex-col">
+        <div className="flex flex-col h-9">
           <Button
             aria-label="Increase value"
-            className="px-2 h-5 rounded-l-none rounded-br-none border-input border-l-0 border-b-[0.5px] focus-visible:relative"
+            className="px-2 h-1/2 rounded-l-none rounded-br-none border-input border-l-0 border-b-[0.5px] focus-visible:relative"
             variant="outline"
             onClick={handleIncrement}
             disabled={displayValue !== undefined && displayValue >= max}
@@ -147,7 +148,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
           </Button>
           <Button
             aria-label="Decrease value"
-            className="px-2 h-5 rounded-l-none rounded-tr-none border-input border-l-0 border-t-[0.5px] focus-visible:relative"
+            className="px-2 h-1/2 rounded-l-none rounded-tr-none border-input border-l-0 border-t-[0.5px] focus-visible:relative"
             variant="outline"
             onClick={handleDecrement}
             disabled={displayValue !== undefined && displayValue <= min}


### PR DESCRIPTION
# Summary
- The number input component comes from [shadcn-number-input](https://github.com/costidotdev/shadcn-number-input), which was modified in the template. The error came from uncorrectly assuming that ref is not undefined.
- Fixed bad buttons height
- I'm leaving deprecated `forwardRef` since the i don't want to touch someone elses component

# Screenshots

Fixed number input:

<img width="668" height="140" alt="image" src="https://github.com/user-attachments/assets/7f1ced36-f3ac-4eec-81f4-e57e6650409e" />


Closes #122 