### PR TITLE
fix: protect against tolocalestring undefined error

### DIFF
--- a/src/features/shared/utils/numbers.ts
+++ b/src/features/shared/utils/numbers.ts
@@ -4,6 +4,11 @@ export const withCurrency = (
   precision: number = 2,
   currency: string = 'USD'
 ) => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (val === undefined || val === null) {
+    console.warn('withCurrency called with undefined or null value');
+    return '';
+  }
   return val.toLocaleString(locale, {
     minimumFractionDigits: precision,
     maximumFractionDigits: precision,


### PR DESCRIPTION
happened when deploying the app

installHook.js:1 TypeError: Cannot read properties of undefined (reading 'toLocaleString')
    at Qt (index-chSqB95a.js:64:80437)
    at index-Mj4ryg0o.js:1:12707
    at Array.map (<anonymous>)
    at ct (index-Mj4ryg0o.js:1:12666)
    at Jv (index-chSqB95a.js:9:34208)
    at vy (index-chSqB95a.js:9:62797)
    at tC (index-chSqB95a.js:9:73362)
    at jC (index-chSqB95a.js:9:107502)
    at W5 (index-chSqB95a.js:9:106561)
    at Uy (index-chSqB95a.js:9:106391)
    
   
the fetch didnt even happen.

happend one line src\features\home\components\account-overview-ribbon.tsx:79 (StatTile's value and calling withCurrency)