### PR TITLE
fix: ticker circle sidebar squashed

### DIFF
--- a/src/features/instruments/components/instrument-image-circle.tsx
+++ b/src/features/instruments/components/instrument-image-circle.tsx
@@ -5,11 +5,12 @@ interface InstrumentIconCircleProps {
   icon: string | null;
   symbol: string;
   name: string;
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'xs' | 'sm' | 'md' | 'lg';
   className?: string;
 }
 
 const sizeClasses = {
+  xs: 'h-4 w-4 text-xs',
   sm: 'h-6 w-6 text-sm',
   md: 'h-10 w-10 text-lg',
   lg: 'h-16 w-16 text-4xl',
@@ -33,7 +34,7 @@ export function InstrumentIconCircle({
     <div
       className={cn([
         sizeClass,
-        `rounded-full border border-muted flex items-center justify-center leading-none text-white`,
+        `rounded-full border border-muted aspect-square flex items-center justify-center leading-none text-white`,
         className,
       ])}
       style={{

--- a/src/features/shared/components/nav-watched-tickers.tsx
+++ b/src/features/shared/components/nav-watched-tickers.tsx
@@ -80,7 +80,8 @@ export function NavWatchedTickers() {
                         symbol={ticker.ticker}
                         icon={ticker.icon ?? null}
                         name={ticker.name}
-                        className="h-4 w-4 rounded-full border-none outline-muted"
+                        size="xs"
+                        className="border-none outline-muted"
                       />
                       <span>{ticker.ticker}</span>
                     </Link>


### PR DESCRIPTION
# Summary

<img width="228" height="729" alt="image" src="https://github.com/user-attachments/assets/d8126712-0ca4-4e73-9269-d7421b748ecc" />

